### PR TITLE
112. Path Sum

### DIFF
--- a/112-path-sum/memo.md
+++ b/112-path-sum/memo.md
@@ -1,0 +1,59 @@
+# ステップ１
+
+根から葉まで行くパスの和がtargetSumになるものがあるかを判定する
+
+まずは再帰で解いてみる。
+再帰関数の引数にtargetを持たせて、target - node.valを左右で再帰させるときのtargetにして
+左右どちらかからtrueが返ってきたらtrueであるという方針。
+
+今回はNoneが渡されたときの例外処理はちゃんとしておく。
+再帰関数の終了条件としてのNoneの返り値と、root=Noneの場合の返り値が異なるため。
+…と思ったが考え方が間違っていた。
+
+```python
+class Solution:
+    def hasPathSum(self, root: Optional[TreeNode], targetSum: int) -> bool:
+        if root is None:
+            return False
+
+        def has_path_sum(node: TreeNode | None, target: int) -> bool:
+            if node is None:
+                return target == 0
+
+            new_target = target - node.val
+            return has_path_sum(node.left, new_target) or has_path_sum(
+                node.right, new_target
+            )
+
+        return has_path_sum(root, targetSum)
+```
+
+これだと片方だけ部分木がある途中のノードでもそこへのpath sumを判定してしまうため正しくなかった。
+例えば[1, 2], targetSum = 1 がTrueになってしまっていた。
+このミスは前もやってしまったような気がする…。
+
+何回かWAしてようやくACした。Noneの扱いがやや面倒…もう少しうまくできなかったか。
+
+top-down式にも書けるのでそれを書いて、それをstack版に翻訳したものも書いた。
+しかし何だか要領を得ない感じがする…path_sumに加算するタイミングが違和感。
+めんどくさがらずに分岐するタイミングでNoneチェックをしたほうがこの場合は分かりやすくなるかもしれない。
+
+# ステップ２
+
+他の人のコードを見る
+
+https://github.com/garunitule/coding_practice/pull/25/files#r2265474303
+
+is_leafはTreeNodeのメソッドにしたい（LeetCodeの仕様として出来ない（無理やりsetattrなどすればできる？））、
+ないしはSolutionから独立した関数としたほうがよいのではないかという意見があった。
+確かにそうかもしれない。
+
+https://github.com/garunitule/coding_practice/pull/25/files#r2265099783
+https://github.com/quinn-sasha/leetcode/pull/24#discussion_r2172911737
+
+「ここまでの」という意味で`so_far`をつけるという表現があるがあまり使わないとのこと。
+自分はそもそもこの語彙が無かったが新しい視点で参考になった。
+
+# ステップ３
+
+３回連続で通せるようになったので一旦完了。

--- a/112-path-sum/step1-recursion-topdown.py
+++ b/112-path-sum/step1-recursion-topdown.py
@@ -1,0 +1,25 @@
+class Solution:
+    def hasPathSum(self, root: Optional[TreeNode], targetSum: int) -> bool:
+        def is_leaf(node: TreeNode) -> bool:
+            return node.left is None and node.right is None
+
+        has_path_sum = False
+
+        def has_path_sum_helper(node: TreeNode | None, path_sum: int):
+            nonlocal has_path_sum
+            if node is None:
+                return
+            if has_path_sum:  # 枝狩り(1個見つかったらそれ以上探索する必要は無い)
+                return
+
+            path_sum += node.val
+            if is_leaf(node):
+                if path_sum == targetSum:
+                    has_path_sum = True
+                return
+
+            has_path_sum_helper(node.left, path_sum)
+            has_path_sum_helper(node.right, path_sum)
+
+        has_path_sum_helper(root, 0)
+        return has_path_sum

--- a/112-path-sum/step1-recursion.py
+++ b/112-path-sum/step1-recursion.py
@@ -1,0 +1,17 @@
+class Solution:
+    def hasPathSum(self, root: Optional[TreeNode], targetSum: int) -> bool:
+        def is_leaf(node: TreeNode) -> bool:
+            return node.left is None and node.right is None
+
+        def has_path_sum(node: TreeNode | None, target: int) -> bool:
+            if node is None:
+                return False
+            if is_leaf(node):
+                return target == node.val
+
+            new_target = target - node.val
+            return has_path_sum(node.left, new_target) or has_path_sum(
+                node.right, new_target
+            )
+
+        return has_path_sum(root, targetSum)

--- a/112-path-sum/step1-stack.py
+++ b/112-path-sum/step1-stack.py
@@ -1,0 +1,18 @@
+class Solution:
+    def hasPathSum(self, root: Optional[TreeNode], targetSum: int) -> bool:
+        def is_leaf(node: TreeNode) -> bool:
+            return node.left is None and node.right is None
+
+        stack = [(root, 0)]
+        while stack:
+            node, path_sum = stack.pop()
+            if node is None:
+                continue
+
+            path_sum += node.val
+            if is_leaf(node) and path_sum == targetSum:
+                return True
+            stack.append((node.left, path_sum))
+            stack.append((node.right, path_sum))
+
+        return False

--- a/112-path-sum/step2-recursion-topdown.py
+++ b/112-path-sum/step2-recursion-topdown.py
@@ -1,0 +1,24 @@
+class Solution:
+    def hasPathSum(self, root: Optional[TreeNode], targetSum: int) -> bool:
+        def is_leaf(node: TreeNode) -> bool:
+            return node.left is None and node.right is None
+
+        has_path_sum = False
+
+        def has_path_sum_helper(node: TreeNode | None, path_sum: int):
+            nonlocal has_path_sum
+            if has_path_sum:  # 枝狩り(1個見つかったらそれ以上探索する必要は無い)
+                return
+
+            path_sum += node.val
+            if is_leaf(node) and path_sum == targetSum:
+                has_path_sum = True
+                return
+
+            if node.left is not None:
+                has_path_sum_helper(node.left, path_sum)
+            if node.right is not None:
+                has_path_sum_helper(node.right, path_sum)
+
+        has_path_sum_helper(root, 0)
+        return has_path_sum

--- a/112-path-sum/step2-stack.py
+++ b/112-path-sum/step2-stack.py
@@ -1,0 +1,20 @@
+class Solution:
+    def hasPathSum(self, root: Optional[TreeNode], targetSum: int) -> bool:
+        def is_leaf(node: TreeNode) -> bool:
+            return node.left is None and node.right is None
+
+        if root is None:
+            return False
+
+        stack = [(root, 0)]
+        while stack:
+            node, path_sum = stack.pop()
+            path_sum += node.val
+            if is_leaf(node) and path_sum == targetSum:
+                return True
+
+            if node.left is not None:
+                stack.append((node.left, path_sum))
+            if node.right is not None:
+                stack.append((node.right, path_sum))
+        return False

--- a/112-path-sum/step3.py
+++ b/112-path-sum/step3.py
@@ -1,0 +1,22 @@
+class Solution:
+    def hasPathSum(self, root: Optional[TreeNode], targetSum: int) -> bool:
+        if root is None:
+            return False
+
+        stack = [(root, 0)]
+        while stack:
+            node, sum_ = stack.pop()
+            sum_ += node.val
+            if is_leaf(node) and sum_ == targetSum:
+                return True
+
+            if node.left is not None:
+                stack.append((node.left, sum_))
+            if node.right is not None:
+                stack.append((node.right, sum_))
+
+        return False
+
+
+def is_leaf(node: TreeNode) -> bool:
+    return node.left is None and node.right is None


### PR DESCRIPTION
## 問題リンク
[112. Path Sum](https://leetcode.com/problems/path-sum/)
<!--
例: [1. Two Sum](https://leetcode.com/problems/two-sum/description/)
-->

## 問題文の概要
Given the root of a binary tree and an integer targetSum, return true if the tree has a root-to-leaf path such that adding up all the values along the path equals targetSum.
<!--
例:
整数配列 nums と整数 target が与えられる。配列内の異なる 2 つの要素の和が target になるような インデックス を返せ。各入力にはちょうど 1 つの解が存在し、同じ要素を 2 回使ってはならない。答えの順序は任意。
-->

## 次に解く予定の問題
[Binary Tree Level Order Traversal](https://leetcode.com/problems/binary-tree-level-order-traversal/)
<!--
例: [1. Two Sum](https://leetcode.com/problems/two-sum/description/)
-->
